### PR TITLE
feat(docker-image-release): pass VERSION and COMMIT as Docker build args

### DIFF
--- a/docker-image-release/README.md
+++ b/docker-image-release/README.md
@@ -10,6 +10,17 @@ Creates a GitHub release using semantic-release and publishes a Docker image to 
 - Creates a `.releaserc.json` for semantic-release.
 - Runs [semantic-release](https://github.com/semantic-release/semantic-release).
 - Publishes a Docker image with `latest` and the new release version tag.
+- Passes `VERSION` (release version) and `COMMIT` (release git SHA) as Docker build args.
+
+To bake these into the image as environment variables, add the following to your `Dockerfile`:
+
+```dockerfile
+ARG VERSION
+ENV VERSION=$VERSION
+
+ARG COMMIT
+ENV COMMIT=$COMMIT
+```
 
 ## Inputs
 

--- a/docker-image-release/action.yml
+++ b/docker-image-release/action.yml
@@ -164,3 +164,6 @@ runs:
           ghcr.io/${{ inputs.image_name }}:${{ steps.semantic.outputs.new_release_version }}
           ghcr.io/${{ inputs.image_name }}:latest
         labels: ${{ steps.docker-meta.outputs.labels }}
+        build-args: |
+          VERSION=${{ steps.semantic.outputs.new_release_version }}
+          COMMIT=${{ steps.semantic.outputs.new_release_git_head }}


### PR DESCRIPTION
## Summary

- Adds `VERSION` (release version) and `COMMIT` (release git SHA) as `build-args` to the Docker build step in `docker-image-release`.
- Updates the README to document that users must add `ARG`/`ENV` declarations in their `Dockerfile` to bake these into the final image.

## Test plan

- [ ] Verify a Docker build using this action receives `VERSION` and `COMMIT` build args.
- [ ] Confirm a `Dockerfile` with the `ARG`/`ENV` declarations exposes them as environment variables in the running container (`docker inspect` or `printenv VERSION COMMIT`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01TQf9S4M6aGJRfxezaSHmzo)_