### PR TITLE
docs(coolify-deploy): document required deployments: write permission

### DIFF
--- a/coolify-deploy/README.md
+++ b/coolify-deploy/README.md
@@ -24,6 +24,15 @@ Triggers one or more Coolify deployments and can optionally wait until they fini
 | `GITHUB_TOKEN` | No | - | GitHub token for setting repository deployment status. |
 | `environment` | No | `production` | GitHub deployment environment name. Only used when `GITHUB_TOKEN` is provided. |
 
+## Permissions
+
+When `GITHUB_TOKEN` is provided, the workflow must grant `deployments: write`:
+
+```yaml
+permissions:
+  deployments: write
+```
+
 ## Usage
 
 ```yaml

--- a/coolify-deploy/action.yml
+++ b/coolify-deploy/action.yml
@@ -32,7 +32,7 @@ inputs:
     required: false
     default: '10'
   GITHUB_TOKEN:
-    description: 'GitHub token for setting repository deployment status. When provided, creates a GitHub deployment and updates its status after the Coolify deployment completes.'
+    description: 'GitHub token for setting repository deployment status. Requires deployments: write permission. When provided, creates a GitHub deployment and updates its status after the Coolify deployment completes.'
     required: false
     default: ''
   environment:


### PR DESCRIPTION
## Summary

Documents the `deployments: write` permission required when using the `GITHUB_TOKEN` input added in #45.

- Adds a `## Permissions` section to the README with the required workflow snippet.
- Updates the `GITHUB_TOKEN` input description in `action.yml` to mention the permission.

## Test plan

- [ ] README renders the permissions section correctly.
- [ ] No build or runtime changes - documentation only.

https://claude.ai/code/session_01GvWQg9mCWiY9idAL6sWzsB