### PR TITLE
feat(coolify-deploy): use latest release tag as GitHub deployment ref

### DIFF
--- a/coolify-deploy/README.md
+++ b/coolify-deploy/README.md
@@ -8,7 +8,7 @@ Triggers one or more Coolify deployments and can optionally wait until they fini
 - Supports forcing a rebuild without cache.
 - Optionally polls Coolify until all triggered deployments finish.
 - Fails when the deploy request fails, a deployment fails, or the wait timeout is reached.
-- Optionally creates a GitHub deployment and tracks its status (`in_progress` → `success` or `failure`) when `GITHUB_TOKEN` is provided.
+- Optionally creates a GitHub deployment and tracks its status (`in_progress` → `success` or `failure`) when `GITHUB_TOKEN` is provided. The deployment ref is set to the latest published release tag, falling back to the current commit SHA if no release exists.
 
 ## Inputs
 
@@ -23,7 +23,6 @@ Triggers one or more Coolify deployments and can optionally wait until they fini
 | `interval` | No | `10` | Polling interval in seconds when waiting for deployments. |
 | `GITHUB_TOKEN` | No | - | GitHub token for setting repository deployment status. |
 | `environment` | No | `production` | GitHub deployment environment name. Only used when `GITHUB_TOKEN` is provided. |
-| `ref` | No | current commit SHA | Git ref (branch, tag, or SHA) to record as the deployed ref in GitHub deployments. Only used when `GITHUB_TOKEN` is provided. |
 
 ## Permissions
 

--- a/coolify-deploy/README.md
+++ b/coolify-deploy/README.md
@@ -23,6 +23,7 @@ Triggers one or more Coolify deployments and can optionally wait until they fini
 | `interval` | No | `10` | Polling interval in seconds when waiting for deployments. |
 | `GITHUB_TOKEN` | No | - | GitHub token for setting repository deployment status. |
 | `environment` | No | `production` | GitHub deployment environment name. Only used when `GITHUB_TOKEN` is provided. |
+| `ref` | No | current commit SHA | Git ref (branch, tag, or SHA) to record as the deployed ref in GitHub deployments. Only used when `GITHUB_TOKEN` is provided. |
 
 ## Permissions
 

--- a/coolify-deploy/action.yml
+++ b/coolify-deploy/action.yml
@@ -39,10 +39,6 @@ inputs:
     description: 'GitHub deployment environment name. Only used when GITHUB_TOKEN is provided.'
     required: false
     default: 'production'
-  ref:
-    description: 'Git ref (branch, tag, or SHA) to record as the deployed ref in GitHub deployments. Defaults to the current commit SHA. Only used when GITHUB_TOKEN is provided.'
-    required: false
-    default: ''
 
 runs:
   using: composite
@@ -64,5 +60,4 @@ runs:
         INPUT_INTERVAL: ${{ inputs.interval }}
         INPUT_GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
         INPUT_ENVIRONMENT: ${{ inputs.environment }}
-        INPUT_REF: ${{ inputs.ref }}
       run: node "${{ github.action_path }}/dist/index.js"

--- a/coolify-deploy/action.yml
+++ b/coolify-deploy/action.yml
@@ -39,6 +39,10 @@ inputs:
     description: 'GitHub deployment environment name. Only used when GITHUB_TOKEN is provided.'
     required: false
     default: 'production'
+  ref:
+    description: 'Git ref (branch, tag, or SHA) to record as the deployed ref in GitHub deployments. Defaults to the current commit SHA. Only used when GITHUB_TOKEN is provided.'
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -60,4 +64,5 @@ runs:
         INPUT_INTERVAL: ${{ inputs.interval }}
         INPUT_GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
         INPUT_ENVIRONMENT: ${{ inputs.environment }}
+        INPUT_REF: ${{ inputs.ref }}
       run: node "${{ github.action_path }}/dist/index.js"

--- a/coolify-deploy/dist/index.js
+++ b/coolify-deploy/dist/index.js
@@ -40704,10 +40704,23 @@ async function requestJson(url, token, httpMethod = "GET") {
     text
   };
 }
-async function createGithubDeployment(octokit, environment, ref) {
+async function getLatestReleaseTag(octokit) {
   try {
     const { owner, repo } = github.context.repo;
-    const deployRef = ref || github.context.sha;
+    const response = await octokit.rest.repos.getLatestRelease({ owner, repo });
+    return response.data.tag_name;
+  } catch {
+    return void 0;
+  }
+}
+async function createGithubDeployment(octokit, environment) {
+  try {
+    const { owner, repo } = github.context.repo;
+    const latestTag = await getLatestReleaseTag(octokit);
+    const deployRef = latestTag ?? github.context.sha;
+    if (latestTag) {
+      info(`\u{1F3F7}\uFE0F Using latest release tag as deployment ref: ${latestTag}`);
+    }
     const response = await octokit.rest.repos.createDeployment({
       auto_merge: false,
       environment,
@@ -40804,7 +40817,6 @@ async function run() {
   const intervalSeconds = parsePositiveIntegerInput("interval", getInput("interval") || "10");
   const githubToken = getInput("GITHUB_TOKEN");
   const environment = getInput("environment") || "production";
-  const ref = getInput("ref").trim() || void 0;
   if (!uuid) {
     setFailed("uuid input is required.");
     return;
@@ -40821,7 +40833,7 @@ async function run() {
   let githubDeploymentId;
   if (githubToken) {
     octokit = github.getOctokit(githubToken);
-    githubDeploymentId = await createGithubDeployment(octokit, environment, ref);
+    githubDeploymentId = await createGithubDeployment(octokit, environment);
     if (githubDeploymentId !== void 0) {
       await setGithubDeploymentStatus(octokit, githubDeploymentId, "in_progress");
     }

--- a/coolify-deploy/dist/index.js
+++ b/coolify-deploy/dist/index.js
@@ -40704,15 +40704,15 @@ async function requestJson(url, token, httpMethod = "GET") {
     text
   };
 }
-async function createGithubDeployment(octokit, environment) {
+async function createGithubDeployment(octokit, environment, ref) {
   try {
     const { owner, repo } = github.context.repo;
-    const ref = github.context.sha;
+    const deployRef = ref || github.context.sha;
     const response = await octokit.rest.repos.createDeployment({
       auto_merge: false,
       environment,
       owner,
-      ref,
+      ref: deployRef,
       repo,
       required_contexts: []
     });
@@ -40804,6 +40804,7 @@ async function run() {
   const intervalSeconds = parsePositiveIntegerInput("interval", getInput("interval") || "10");
   const githubToken = getInput("GITHUB_TOKEN");
   const environment = getInput("environment") || "production";
+  const ref = getInput("ref").trim() || void 0;
   if (!uuid) {
     setFailed("uuid input is required.");
     return;
@@ -40820,7 +40821,7 @@ async function run() {
   let githubDeploymentId;
   if (githubToken) {
     octokit = github.getOctokit(githubToken);
-    githubDeploymentId = await createGithubDeployment(octokit, environment);
+    githubDeploymentId = await createGithubDeployment(octokit, environment, ref);
     if (githubDeploymentId !== void 0) {
       await setGithubDeploymentStatus(octokit, githubDeploymentId, "in_progress");
     }

--- a/coolify-deploy/src/__tests__/run.test.ts
+++ b/coolify-deploy/src/__tests__/run.test.ts
@@ -24,6 +24,7 @@ function setupInputs(overrides: Record<string, string> = {}): void {
     interval: '10',
     GITHUB_TOKEN: '',
     environment: 'production',
+    ref: '',
   };
 
   mockGetInput.mockImplementation((name: string) => overrides[name] ?? defaults[name] ?? '');
@@ -251,6 +252,46 @@ describe('run', () => {
       await run();
 
       expect(mockCreateDeployment).toHaveBeenCalledWith(expect.objectContaining({environment: 'staging'}));
+    });
+
+    it('uses provided ref when creating deployment', async () => {
+      setupInputs({GITHUB_TOKEN: 'gh-token', ref: 'v1.2.3'});
+      setupOctokit();
+      mockCreateDeployment.mockResolvedValue({status: 201, data: {id: 8}});
+      mockCreateDeploymentStatus.mockResolvedValue({});
+
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          status: 200,
+          text: async () => JSON.stringify({deployments: [{deployment_uuid: 'deployment-1'}]}),
+        })
+      );
+
+      const {run} = await import('..');
+      await run();
+
+      expect(mockCreateDeployment).toHaveBeenCalledWith(expect.objectContaining({ref: 'v1.2.3'}));
+    });
+
+    it('falls back to context sha when ref is not provided', async () => {
+      setupInputs({GITHUB_TOKEN: 'gh-token', ref: ''});
+      setupOctokit();
+      mockCreateDeployment.mockResolvedValue({status: 201, data: {id: 9}});
+      mockCreateDeploymentStatus.mockResolvedValue({});
+
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          status: 200,
+          text: async () => JSON.stringify({deployments: [{deployment_uuid: 'deployment-1'}]}),
+        })
+      );
+
+      const {run} = await import('..');
+      await run();
+
+      expect(mockCreateDeployment).toHaveBeenCalledWith(expect.objectContaining({ref: 'abc123'}));
     });
   });
 });

--- a/coolify-deploy/src/__tests__/run.test.ts
+++ b/coolify-deploy/src/__tests__/run.test.ts
@@ -12,6 +12,7 @@ const mockGetOctokit = vi.mocked(github.getOctokit);
 
 const mockCreateDeployment = vi.fn();
 const mockCreateDeploymentStatus = vi.fn();
+const mockGetLatestRelease = vi.fn();
 
 function setupInputs(overrides: Record<string, string> = {}): void {
   const defaults: Record<string, string> = {
@@ -24,18 +25,20 @@ function setupInputs(overrides: Record<string, string> = {}): void {
     interval: '10',
     GITHUB_TOKEN: '',
     environment: 'production',
-    ref: '',
   };
 
   mockGetInput.mockImplementation((name: string) => overrides[name] ?? defaults[name] ?? '');
 }
 
 function setupOctokit(): void {
+  mockGetLatestRelease.mockResolvedValue({data: {tag_name: 'v1.0.0'}});
+
   mockGetOctokit.mockReturnValue({
     rest: {
       repos: {
         createDeployment: mockCreateDeployment,
         createDeploymentStatus: mockCreateDeploymentStatus,
+        getLatestRelease: mockGetLatestRelease,
       },
     },
   } as unknown as ReturnType<typeof github.getOctokit>);
@@ -153,7 +156,7 @@ describe('run', () => {
       await run();
 
       expect(mockCreateDeployment).toHaveBeenCalledWith(
-        expect.objectContaining({owner: 'test-owner', repo: 'test-repo', ref: 'abc123', environment: 'production'})
+        expect.objectContaining({owner: 'test-owner', repo: 'test-repo', ref: 'v1.0.0', environment: 'production'})
       );
       expect(mockCreateDeploymentStatus).toHaveBeenCalledWith(
         expect.objectContaining({deployment_id: 42, state: 'in_progress'})
@@ -254,9 +257,10 @@ describe('run', () => {
       expect(mockCreateDeployment).toHaveBeenCalledWith(expect.objectContaining({environment: 'staging'}));
     });
 
-    it('uses provided ref when creating deployment', async () => {
-      setupInputs({GITHUB_TOKEN: 'gh-token', ref: 'v1.2.3'});
+    it('uses latest release tag as deployment ref', async () => {
+      setupInputs({GITHUB_TOKEN: 'gh-token'});
       setupOctokit();
+      mockGetLatestRelease.mockResolvedValue({data: {tag_name: 'v2.3.4'}});
       mockCreateDeployment.mockResolvedValue({status: 201, data: {id: 8}});
       mockCreateDeploymentStatus.mockResolvedValue({});
 
@@ -271,12 +275,13 @@ describe('run', () => {
       const {run} = await import('..');
       await run();
 
-      expect(mockCreateDeployment).toHaveBeenCalledWith(expect.objectContaining({ref: 'v1.2.3'}));
+      expect(mockCreateDeployment).toHaveBeenCalledWith(expect.objectContaining({ref: 'v2.3.4'}));
     });
 
-    it('falls back to context sha when ref is not provided', async () => {
-      setupInputs({GITHUB_TOKEN: 'gh-token', ref: ''});
+    it('falls back to context sha when no release exists', async () => {
+      setupInputs({GITHUB_TOKEN: 'gh-token'});
       setupOctokit();
+      mockGetLatestRelease.mockRejectedValue(new Error('Not Found'));
       mockCreateDeployment.mockResolvedValue({status: 201, data: {id: 9}});
       mockCreateDeploymentStatus.mockResolvedValue({});
 

--- a/coolify-deploy/src/index.ts
+++ b/coolify-deploy/src/index.ts
@@ -53,16 +53,20 @@ async function requestJson<T>(
   };
 }
 
-async function createGithubDeployment(octokit: Octokit, environment: string): Promise<number | undefined> {
+async function createGithubDeployment(
+  octokit: Octokit,
+  environment: string,
+  ref?: string
+): Promise<number | undefined> {
   try {
     const {owner, repo} = github.context.repo;
-    const ref = github.context.sha;
+    const deployRef = ref || github.context.sha;
 
     const response = await octokit.rest.repos.createDeployment({
       auto_merge: false,
       environment,
       owner,
-      ref,
+      ref: deployRef,
       repo,
       required_contexts: [],
     });
@@ -182,6 +186,7 @@ export async function run(): Promise<void> {
   const intervalSeconds = parsePositiveIntegerInput('interval', core.getInput('interval') || '10');
   const githubToken = core.getInput('GITHUB_TOKEN');
   const environment = core.getInput('environment') || 'production';
+  const ref = core.getInput('ref').trim() || undefined;
 
   if (!uuid) {
     core.setFailed('uuid input is required.');
@@ -203,7 +208,7 @@ export async function run(): Promise<void> {
 
   if (githubToken) {
     octokit = github.getOctokit(githubToken);
-    githubDeploymentId = await createGithubDeployment(octokit, environment);
+    githubDeploymentId = await createGithubDeployment(octokit, environment, ref);
     if (githubDeploymentId !== undefined) {
       await setGithubDeploymentStatus(octokit, githubDeploymentId, 'in_progress');
     }

--- a/coolify-deploy/src/index.ts
+++ b/coolify-deploy/src/index.ts
@@ -53,14 +53,25 @@ async function requestJson<T>(
   };
 }
 
-async function createGithubDeployment(
-  octokit: Octokit,
-  environment: string,
-  ref?: string
-): Promise<number | undefined> {
+async function getLatestReleaseTag(octokit: Octokit): Promise<string | undefined> {
   try {
     const {owner, repo} = github.context.repo;
-    const deployRef = ref || github.context.sha;
+    const response = await octokit.rest.repos.getLatestRelease({owner, repo});
+    return response.data.tag_name;
+  } catch {
+    return undefined;
+  }
+}
+
+async function createGithubDeployment(octokit: Octokit, environment: string): Promise<number | undefined> {
+  try {
+    const {owner, repo} = github.context.repo;
+    const latestTag = await getLatestReleaseTag(octokit);
+    const deployRef = latestTag ?? github.context.sha;
+
+    if (latestTag) {
+      core.info(`🏷️ Using latest release tag as deployment ref: ${latestTag}`);
+    }
 
     const response = await octokit.rest.repos.createDeployment({
       auto_merge: false,
@@ -186,7 +197,6 @@ export async function run(): Promise<void> {
   const intervalSeconds = parsePositiveIntegerInput('interval', core.getInput('interval') || '10');
   const githubToken = core.getInput('GITHUB_TOKEN');
   const environment = core.getInput('environment') || 'production';
-  const ref = core.getInput('ref').trim() || undefined;
 
   if (!uuid) {
     core.setFailed('uuid input is required.');
@@ -208,7 +218,7 @@ export async function run(): Promise<void> {
 
   if (githubToken) {
     octokit = github.getOctokit(githubToken);
-    githubDeploymentId = await createGithubDeployment(octokit, environment, ref);
+    githubDeploymentId = await createGithubDeployment(octokit, environment);
     if (githubDeploymentId !== undefined) {
       await setGithubDeploymentStatus(octokit, githubDeploymentId, 'in_progress');
     }


### PR DESCRIPTION
When `GITHUB_TOKEN` is provided, automatically fetches the latest published release tag via the GitHub API and uses it as the ref on the created GitHub deployment. Falls back to the current commit SHA if no release exists.

No new inputs are required.

## Changes

- `createGithubDeployment` now calls `repos.getLatestRelease` and uses the returned tag name as the deployment ref
- Falls back to `github.context.sha` when no published release exists
- Updated README to document the new behavior