### PR TITLE
feat(coolify-deploy): log when tag is unavailable and SHA is used as deployment ref

### DIFF
--- a/coolify-deploy/dist/index.js
+++ b/coolify-deploy/dist/index.js
@@ -23838,6 +23838,8 @@ async function createGithubDeployment(octokit, environment) {
     const deployRef = latestTag ?? context2.sha;
     if (latestTag) {
       info(`\u{1F3F7}\uFE0F Using latest release tag as deployment ref: ${latestTag}`);
+    } else {
+      info(`\u2139\uFE0F No release tag found; using commit SHA as deployment ref: ${context2.sha}`);
     }
     const response = await octokit.rest.repos.createDeployment({
       auto_merge: false,

--- a/coolify-deploy/src/__tests__/run.test.ts
+++ b/coolify-deploy/src/__tests__/run.test.ts
@@ -297,6 +297,7 @@ describe('run', () => {
       await run();
 
       expect(mockCreateDeployment).toHaveBeenCalledWith(expect.objectContaining({ref: 'abc123'}));
+      expect(mockInfo).toHaveBeenCalledWith('ℹ️ No release tag found; using commit SHA as deployment ref: abc123');
     });
   });
 });

--- a/coolify-deploy/src/index.ts
+++ b/coolify-deploy/src/index.ts
@@ -71,6 +71,8 @@ async function createGithubDeployment(octokit: Octokit, environment: string): Pr
 
     if (latestTag) {
       core.info(`🏷️ Using latest release tag as deployment ref: ${latestTag}`);
+    } else {
+      core.info(`ℹ️ No release tag found; using commit SHA as deployment ref: ${github.context.sha}`);
     }
 
     const response = await octokit.rest.repos.createDeployment({


### PR DESCRIPTION
## Summary

- Adds an `else` branch in `createGithubDeployment` to log when no release tag is found and the commit SHA is used as the deployment ref instead
- Updates the existing "falls back to context sha" test to assert the new log message

## Test plan

- [ ] Existing test suite passes (`CI=true yarn test` in `coolify-deploy/`)
- [ ] `yarn type-check` and `yarn build` pass cleanly

https://claude.ai/code/session_0156H2K3PvFY8QcZxZPLtUMk

---
_Generated by [Claude Code](https://claude.ai/code/session_0156H2K3PvFY8QcZxZPLtUMk)_