### PR TITLE
fix(coolify-deploy): wait 5s before fetching latest release tag

### DIFF
--- a/coolify-deploy/dist/index.js
+++ b/coolify-deploy/dist/index.js
@@ -23823,6 +23823,7 @@ async function requestJson(url, token, httpMethod = "GET") {
   };
 }
 async function getLatestReleaseTag(octokit) {
+  await sleep(5e3);
   try {
     const { owner, repo } = context2.repo;
     const response = await octokit.rest.repos.getLatestRelease({ owner, repo });

--- a/coolify-deploy/src/__tests__/run.test.ts
+++ b/coolify-deploy/src/__tests__/run.test.ts
@@ -138,6 +138,10 @@ describe('run', () => {
   });
 
   describe('GitHub deployment status', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
     it('creates a deployment and sets in_progress then success when not waiting', async () => {
       setupInputs({GITHUB_TOKEN: 'gh-token'});
       setupOctokit();
@@ -153,7 +157,9 @@ describe('run', () => {
       );
 
       const {run} = await import('..');
-      await run();
+      const runPromise = run();
+      await vi.runAllTimersAsync();
+      await runPromise;
 
       expect(mockCreateDeployment).toHaveBeenCalledWith(
         expect.objectContaining({owner: 'test-owner', repo: 'test-repo', ref: 'v1.0.0', environment: 'production'})
@@ -181,7 +187,10 @@ describe('run', () => {
       );
 
       const {run} = await import('..');
-      await expect(run()).rejects.toThrow('Deployment request failed with HTTP status 500.');
+      const runPromise = run();
+      const assertion = expect(runPromise).rejects.toThrow('Deployment request failed with HTTP status 500.');
+      await vi.runAllTimersAsync();
+      await assertion;
 
       expect(mockCreateDeploymentStatus).toHaveBeenCalledWith(
         expect.objectContaining({deployment_id: 42, state: 'in_progress'})
@@ -208,7 +217,6 @@ describe('run', () => {
           text: async () => JSON.stringify({status: 'successful', application_name: 'my-app'}),
         });
       vi.stubGlobal('fetch', fetchMock);
-      vi.useFakeTimers();
 
       const {run} = await import('..');
       const runPromise = run();
@@ -252,7 +260,9 @@ describe('run', () => {
       );
 
       const {run} = await import('..');
-      await run();
+      const runPromise = run();
+      await vi.runAllTimersAsync();
+      await runPromise;
 
       expect(mockCreateDeployment).toHaveBeenCalledWith(expect.objectContaining({environment: 'staging'}));
     });
@@ -273,7 +283,9 @@ describe('run', () => {
       );
 
       const {run} = await import('..');
-      await run();
+      const runPromise = run();
+      await vi.runAllTimersAsync();
+      await runPromise;
 
       expect(mockCreateDeployment).toHaveBeenCalledWith(expect.objectContaining({ref: 'v2.3.4'}));
     });
@@ -294,7 +306,9 @@ describe('run', () => {
       );
 
       const {run} = await import('..');
-      await run();
+      const runPromise = run();
+      await vi.runAllTimersAsync();
+      await runPromise;
 
       expect(mockCreateDeployment).toHaveBeenCalledWith(expect.objectContaining({ref: 'abc123'}));
       expect(mockInfo).toHaveBeenCalledWith('ℹ️ No release tag found; using commit SHA as deployment ref: abc123');

--- a/coolify-deploy/src/index.ts
+++ b/coolify-deploy/src/index.ts
@@ -54,6 +54,7 @@ async function requestJson<T>(
 }
 
 async function getLatestReleaseTag(octokit: Octokit): Promise<string | undefined> {
+  await sleep(5000);
   try {
     const {owner, repo} = github.context.repo;
     const response = await octokit.rest.repos.getLatestRelease({owner, repo});


### PR DESCRIPTION
## What changed

Added a 5-second delay in `getLatestReleaseTag` before querying the GitHub API for the latest release.

## Why

When this action runs immediately after a release is published, the GitHub API sometimes hasn't propagated the new tag yet, causing the action to fall back to the commit SHA instead of the tag. The short wait gives the API time to catch up.

## Notes for reviewers

- The delay is implemented by reusing the existing `sleep` helper already present in `index.ts`.
- Tests updated to use `vi.useFakeTimers()` in the `GitHub deployment status` describe block (via `beforeEach`) so the sleep doesn't slow down the test suite. All 21 tests pass.