### PR TITLE
fix(coolify-deploy): log error when tag fetch fails before falling back to SHA

### DIFF
--- a/coolify-deploy/dist/index.js
+++ b/coolify-deploy/dist/index.js
@@ -23828,7 +23828,8 @@ async function getLatestReleaseTag(octokit) {
     const { owner, repo } = context2.repo;
     const response = await octokit.rest.repos.getLatestRelease({ owner, repo });
     return response.data.tag_name;
-  } catch {
+  } catch (error2) {
+    warning(`Failed to fetch latest release tag: ${error2 instanceof Error ? error2.message : String(error2)}`);
     return void 0;
   }
 }

--- a/coolify-deploy/src/index.ts
+++ b/coolify-deploy/src/index.ts
@@ -59,7 +59,8 @@ async function getLatestReleaseTag(octokit: Octokit): Promise<string | undefined
     const {owner, repo} = github.context.repo;
     const response = await octokit.rest.repos.getLatestRelease({owner, repo});
     return response.data.tag_name;
-  } catch {
+  } catch (error) {
+    core.warning(`Failed to fetch latest release tag: ${error instanceof Error ? error.message : String(error)}`);
     return undefined;
   }
 }


### PR DESCRIPTION
## Summary

- The `catch` block in `getLatestReleaseTag` was silently discarding the error before returning `undefined`
- Now logs the error message via `core.warning` so the reason for the fallback to commit SHA is visible in the action logs

## Test plan

- [ ] Existing tests pass (`yarn test`)
- [ ] Type-check passes (`yarn type-check`)
- [ ] Bundle rebuilt (`yarn build`)