### PR TITLE
feat(docker-image-release): add optional DOCKER_TOKEN input for Docker Hub publishing

### DIFF
--- a/docker-image-release/README.md
+++ b/docker-image-release/README.md
@@ -1,15 +1,16 @@
 # Docker Image Release
 
-Creates a GitHub release using semantic-release and publishes a Docker image to GHCR.
+Creates a GitHub release using semantic-release and publishes a Docker image to GHCR and optionally Docker Hub.
 
 ## What It Does
 
 - Checks out the repository.
 - Logs in to GitHub Container Registry.
+- Logs in to Docker Hub (when `DOCKER_TOKEN` is set).
 - Extracts Docker metadata for image labels.
 - Creates a `.releaserc.json` for semantic-release.
 - Runs [semantic-release](https://github.com/semantic-release/semantic-release).
-- Publishes a Docker image with `latest` and the new release version tag.
+- Publishes a Docker image with `latest` and the new release version tag to GHCR and, optionally, Docker Hub.
 - Passes `VERSION` (release version) and `COMMIT` (release git SHA) as Docker build args.
 
 To bake these into the image as environment variables, add the following to your `Dockerfile`:
@@ -24,12 +25,13 @@ ENV COMMIT=$COMMIT
 
 ## Inputs
 
-| Name            | Required | Default        | Description                                                       |
-| --------------- | -------- | -------------- | ----------------------------------------------------------------- |
-| `GITHUB_TOKEN`  | Yes      | -              | Token used by semantic-release and GHCR publish.                  |
-| `git_author`    | Yes      | -              | Git author/committer name used for release commits.               |
-| `git_email`     | Yes      | -              | Git author/committer email used for release commits.              |
-| `publish_files` | No       | `CHANGELOG.md` | Newline-separated list of files to include in the release commit. |
+| Name            | Required | Default        | Description                                                                                              |
+| --------------- | -------- | -------------- | -------------------------------------------------------------------------------------------------------- |
+| `GITHUB_TOKEN`  | Yes      | -              | Token used by semantic-release and GHCR publish.                                                         |
+| `DOCKER_TOKEN`  | No       | -              | Docker Hub token. When set, the image is also published to Docker Hub using `github.repository_owner` as the username. |
+| `git_author`    | Yes      | -              | Git author/committer name used for release commits.                                                      |
+| `git_email`     | Yes      | -              | Git author/committer email used for release commits.                                                     |
+| `publish_files` | No       | `CHANGELOG.md` | Newline-separated list of files to include in the release commit.                                        |
 
 ## Outputs
 

--- a/docker-image-release/action.yml
+++ b/docker-image-release/action.yml
@@ -1,6 +1,6 @@
 ---
 name: Create Docker Image Release
-description: Create a GitHub release and publish a Docker image to GHCR
+description: Create a GitHub release and publish a Docker image to GHCR and optionally Docker Hub
 author: 'Florian Imdahl <git@ffflorian.de>'
 branding: {icon: 'check', color: 'green'}
 
@@ -8,6 +8,10 @@ inputs:
   GITHUB_TOKEN:
     description: 'GitHub token to create the release and publish the image.'
     required: true
+  DOCKER_TOKEN:
+    description: 'Docker Hub token. When set, the image is also published to Docker Hub.'
+    required: false
+    default: ''
   git_author:
     description: 'The author to use for the release commit.'
     required: true
@@ -74,6 +78,13 @@ runs:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ inputs.GITHUB_TOKEN }}
+
+    - name: Log in to Docker Hub
+      if: inputs.DOCKER_TOKEN != ''
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
+      with:
+        username: ${{ github.repository_owner }}
+        password: ${{ inputs.DOCKER_TOKEN }}
 
     - name: Setup Node.js
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
@@ -154,15 +165,33 @@ runs:
         tags: |
           type=raw,value=latest,enable=true
 
+    - name: Prepare image tags
+      id: image-tags
+      if: steps.semantic.outputs.new_release_version != ''
+      shell: bash
+      env:
+        DOCKER_TOKEN: ${{ inputs.DOCKER_TOKEN }}
+        IMAGE_NAME: ${{ inputs.image_name }}
+        VERSION: ${{ steps.semantic.outputs.new_release_version }}
+      run: |
+        {
+          echo 'tags<<EOF'
+          echo "ghcr.io/${IMAGE_NAME}:${VERSION}"
+          echo "ghcr.io/${IMAGE_NAME}:latest"
+          if [ -n "${DOCKER_TOKEN}" ]; then
+            echo "docker.io/${IMAGE_NAME}:${VERSION}"
+            echo "docker.io/${IMAGE_NAME}:latest"
+          fi
+          echo 'EOF'
+        } >> "$GITHUB_OUTPUT"
+
     - name: Build and push Docker image
       if: steps.semantic.outputs.new_release_version != ''
       uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
       with:
         context: .
         push: true
-        tags: |
-          ghcr.io/${{ inputs.image_name }}:${{ steps.semantic.outputs.new_release_version }}
-          ghcr.io/${{ inputs.image_name }}:latest
+        tags: ${{ steps.image-tags.outputs.tags }}
         labels: ${{ steps.docker-meta.outputs.labels }}
         build-args: |
           VERSION=${{ steps.semantic.outputs.new_release_version }}


### PR DESCRIPTION
When DOCKER_TOKEN is set, the action logs in to Docker Hub using
github.repository_owner as the username and pushes the image to
docker.io in addition to ghcr.io.

https://claude.ai/code/session_0171vB5Kcm8ZQz9H9YW5mnUq