### PR TITLE
ci: group Dependabot npm updates by dependency name across directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,9 @@ updates:
       - /force-release
       - /hugo-theme-update
       - /yarn-update
+    groups:
+      cross-directory-deps:
+        group-by: dependency-name
     ignore:
       - dependency-name: '@types/node'
         update-types:


### PR DESCRIPTION
Uses group-by: dependency-name so a shared dependency bump (e.g. typescript,
vitest) produces one PR across coolify-deploy, force-release,
hugo-theme-update, and yarn-update instead of one per directory.